### PR TITLE
CVE-2016-1625 & CVE-2011-3045

### DIFF
--- a/cves/CVE-2011-3045.yml
+++ b/cves/CVE-2011-3045.yml
@@ -118,8 +118,8 @@ major_events:
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
   answer: |
-    This vulnerability exists in a third party library used by Chromium, as such
-    the deveopers of Chromium didn't interact with this file alot, leaving only a
+    This vulnerability exists in a third-party library used by Chromium, as such
+    the developers of Chromium didn't interact with this file a lot, leaving only a
     handful of commits within the 2 years this bug was active.
   events:
   - name: 
@@ -188,16 +188,15 @@ mistakes:
     they have written there. Are they doing those? Does the fix look proper?
 
     Use those questions to inspire your answer. Don't feel obligated to answer
-    every one. Write a thoughtful entry here that those ing the software
+    every one. Write a thoughtful entry here that those in the software
     engineering industry would find interesting.
   answer: |
-    I believe the mistake made that resulting in this vulnerability occured due
-    to the teams acceptance of the thrid party library, it appears they assumed
-    the library would take care of most of the things that could result in a
-    vulnerability without actually checking if it did. When they first introduced
-    this bug, they probably weren't thinking a PNG file can unpack to overflow a
-    32-bit integer.
-    Additionally there doesn't appear to be any unit tests related to the library,
-    which means they assumed the open-source nature of the library would result
-    in fixed security issues. While this is true, there was a decent amount of
+    I believe the mistake made that resulted in this vulnerability occurred due
+    to the team's acceptance of the third-party library, it appears they assumed
+    the library would take care of the vulnerabilities within without checking 
+    if it did. When they first introduced this bug, they probably didn't realize
+    a PNG file can unpack to overflow a 32-bit integer.
+    Additionally, there doesn't appear to be any unit tests related to the library,
+    which means they assumed its open-source nature would result in security issues
+    being fixed without much hassle. While this is true, there was a length of
     time between the issue and the fix where special PNG images could DoS Chromium.

--- a/cves/CVE-2011-3045.yml
+++ b/cves/CVE-2011-3045.yml
@@ -42,8 +42,7 @@ fixes:
   :note: fixed security issues with 32 & 64 bit integers
 vccs: 
 - :commit: 71b9d6403ceaaef6b2b258fbb32f1a77b7c875e6
-  :note: Vulnerability was introduced from updating an external library to
-  fix another issue
+  :note: Introduced from updating an external library to fix another issue
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -107,8 +106,9 @@ interesting_commits:
     emerging themes?
   commits:
   - commit: 6f7a602151b8a9c4437f9756766782d8b0f8196f
-    note: Library was updated again to fix a different vulnerability. This issue
-    must have existed in both versions of the libpng library
+    note: |
+      Library was updated again to fix a different vulnerability. This issue
+      must have existed in both versions of the libpng library
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -156,10 +156,10 @@ lessons:
   distrust_input:
     applies: true
     note: |
-    The developers didn't think that an image file could be crafted in such
-    a way that when unpacked for use in the browser, the image overflows a 32-bit
-    integer. There was an assumption that the input image would be valid, and 
-    reasonably sized.
+      The developers didn't think that an image file could be crafted in such
+      a way that when unpacked for use in the browser, the image overflows a 32-bit
+      integer. There was an assumption that the input image would be valid, and 
+      reasonably sized.
   security_by_obscurity:
     applies: false
     note: 

--- a/cves/CVE-2011-3045.yml
+++ b/cves/CVE-2011-3045.yml
@@ -67,7 +67,7 @@ unit_tested:
     It does not appear that unit tests were part of finding the vulnerability,
     although they were used to help recreate & fix the issue.
   code: false
-  fix: false
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -83,7 +83,10 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer: ''    
+  answer: |
+    This vulnerability was discovered manually by a user, not from Google, by simply
+    navigating to a website specifically designed to serve crafted PNG files for
+    testing and security purposes.
   date: 2012-02-28
   automated: false
   google: false
@@ -176,8 +179,11 @@ lessons:
     applies: false
     note: 
   complex_inputs:
-    applies: false
-    note: 
+    applies: true
+    note: |
+      Due to the nature of this vulnerability, the only way to trigger it is with
+      a specificly crafted PNG file, thus requiring a file much more complex than
+      any ordinary image.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that

--- a/cves/CVE-2011-3045.yml
+++ b/cves/CVE-2011-3045.yml
@@ -1,6 +1,6 @@
 ---
 CVE: CVE-2011-3045
-CWE: 
+CWE: 189
 announced: 2012-03-22 12:55:01.160000000 -04:00
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -15,11 +15,15 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+  Lack of a controlled space for use in an added image library allowed for certain
+  PNG images to expand to 3 or 4 Gigabytes in size, triggering a 32-bit signed
+  integer overflow leading to a Denial of Service.
 bounty:
   date: 
   amount: 
-  references: []
+  references: 
+  - https://chromereleases.googleblog.com/2012/03/stable-channel-update_21.html
 reviews:
 - 9546033
 - 9363013
@@ -33,10 +37,13 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 4cf106cdb83dd6b35d3b26d06cc67d1d2d99041e
-  :note: ''
+  :note: Limits the amount of space allowed for unpacked images
 - :commit: 6e8e1fd24400ecbf1153162e67100ad7665c2679
-  :note: ''
-vccs: []
+  :note: fixed security issues with 32 & 64 bit integers
+vccs: 
+- :commit: 71b9d6403ceaaef6b2b258fbb32f1a77b7c875e6
+  :note: Vulnerability was introduced from updating an external library to
+  fix another issue
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -57,9 +64,11 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer: |
+    It does not appear that unit tests were part of finding the vulnerability,
+    although they were used to help recreate & fix the issue.
+  code: false
+  fix: false
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -68,18 +77,18 @@ discovered:
     originally found. Answer in longform below in "answer", fill in the date in
     YYYY-MM-DD, and then determine if the vulnerability was found by a Google
     employee (you can tell from their email address). If it's clear that the
-    vulenrability was discovered by a contest, fill in the name there.
+    vulnerability was discovered by a contest, fill in the name there.
 
     The "automated" flag can be true, false, or nil.
     The "google" flag can be true, false, or nil.
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer: ''    
+  date: 2012-02-28
+  automated: false
+  google: false
+  contest: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -87,8 +96,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
-  answer: 
-  name: 
+  answer: Third Party Library
+  name: libpng
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -97,10 +106,9 @@ interesting_commits:
     interesting in light of the lessons learned from this vulnerability. Any
     emerging themes?
   commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+  - commit: 6f7a602151b8a9c4437f9756766782d8b0f8196f
+    note: Library was updated again to fix a different vulnerability. This issue
+    must have existed in both versions of the libpng library
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -109,7 +117,10 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
+  answer: |
+    This vulnerability exists in a third party library used by Chromium, as such
+    the deveopers of Chromium didn't interact with this file alot, leaving only a
+    handful of commits within the 2 years this bug was active.
   events:
   - name: 
     date: 
@@ -131,37 +142,41 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies: 
+    applies: false
     note: 
   least_privilege:
-    applies: 
+    applies: false
     note: 
   frameworks_are_optional:
-    applies: 
+    applies: false
     note: 
   native_wrappers:
-    applies: 
+    applies: false
     note: 
   distrust_input:
-    applies: 
-    note: 
+    applies: true
+    note: |
+    The developers didn't think that an image file could be crafted in such
+    a way that when unpacked for use in the browser, the image overflows a 32-bit
+    integer. There was an assumption that the input image would be valid, and 
+    reasonably sized.
   security_by_obscurity:
-    applies: 
+    applies: false
     note: 
   serial_killer:
-    applies: 
+    applies: false
     note: 
   environment_variables:
-    applies: 
+    applies: false
     note: 
   secure_by_default:
-    applies: 
+    applies: false
     note: 
   yagni:
-    applies: 
+    applies: false
     note: 
   complex_inputs:
-    applies: 
+    applies: false
     note: 
 mistakes:
   question: |
@@ -175,4 +190,14 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    I believe the mistake made that resulting in this vulnerability occured due
+    to the teams acceptance of the thrid party library, it appears they assumed
+    the library would take care of most of the things that could result in a
+    vulnerability without actually checking if it did. When they first introduced
+    this bug, they probably weren't thinking a PNG file can unpack to overflow a
+    32-bit integer.
+    Additionally there doesn't appear to be any unit tests related to the library,
+    which means they assumed the open-source nature of the library would result
+    in fixed security issues. While this is true, there was a decent amount of
+    time between the issue and the fix where special PNG images could DoS Chromium.

--- a/cves/CVE-2016-1625.yml
+++ b/cves/CVE-2016-1625.yml
@@ -82,8 +82,7 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer: |
-  
+  answer: ''
   date: 2015-07-12
   automated: false
   google: true
@@ -107,24 +106,24 @@ interesting_commits:
   commits:
   - commit: ce767ab228df8ab9ee2664a258380ce9601fc42b
     note: |
-    Added support for forced URLs in the TopSites. Allows Chrome to force, and keep
-    top-sites according to the most recently used metric. Allows for certain sites
-    to appear on the New Tab Page over other web pages. Current implementation shows
-    only 8 sites on the NTP, so this provides more customization to those sites.
+      Added support for forced URLs in the TopSites. Allows Chrome to force, and keep
+      top-sites according to the most recently used metric. Allows for certain sites
+      to appear on the New Tab Page over other web pages. Current implementation shows
+      only 8 sites on the NTP, so this provides more customization to those sites.
   - commit: 8d57a0152613119d7e6369838fd5838fb7773e68
     note: |
-    Rework of the New Tab Page to remove anything that dealt with an older version of
-    the NTP still referenced in the code. This is the second commit of this nature, the
-    first one was reverted.
+      Rework of the New Tab Page to remove anything that dealt with an older version of
+      the NTP still referenced in the code. This is the second commit of this nature, the
+      first one was reverted.
   - commit: 982ecc2f027bc08255e8dd6a37017b69bde250f7
     note: |
-    Experimental code used to test the Most Visited Tiles functionality on the New
-    Tab Page is considered obsolete at this point and was removed from the repo.
+      Experimental code used to test the Most Visited Tiles functionality on the New
+      Tab Page is considered obsolete at this point and was removed from the repo.
   - commit: 51bbec7be7014d4d75d39c1a5c27b1ba9ddc3dcd
     note: |
-    Involved the movement of a fair number of the search functionality into a
-    different namespace. Could have attributed to the length of time this 
-    vulnerability sat in the repo.
+      Involved the movement of a fair number of the search functionality into a
+      different namespace. Could have attributed to the length of time this 
+      vulnerability sat in the repo.
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -134,16 +133,16 @@ major_events:
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
   answer: |
-  It is assumed the team changed within the 3 years this vulnerability was active.
-  The New Tab Page and Chrome Instant, where both reworked and semi-componentized
-  within this time which could help account for the length of time the vulnerability
-  was active.
+    It is assumed the team changed within the 3 years this vulnerability was active.
+    The New Tab Page and Chrome Instant, where both reworked and semi-componentized
+    within this time which could help account for the length of time the vulnerability
+    was active.
   events:
-  - name: Componentized Search functions, code was moved to another namespace to
-  accomodate Chrome on iOS.
+  - name: |
+  Componentized Search functions, code was moved to another namespace to accomodate iOS.
     date: 2015-08-03
-  - name: Experimental code dealing with Most Visited Tiles on the NTP was removed 
-  from Chrome
+  - name: |
+  Experimental code dealing with Most Visited Tiles on the NTP was removed from Chrome
     date: 2014-07-23
 lessons:
   question: |
@@ -163,19 +162,19 @@ lessons:
   defense_in_depth:
     applies: true
     note: |
-    It was assumed that the extensions within Chrome were not capable of 
-    navigating to, downloading a file from a URL, or execute the downloaded 
-    file without user interaction. Thus the developers didn't originally think
-    to check that the target links given on the NTP should all be in the most-
-    visited or suggested link lists. The fix was to add another layer of defense
-    to Chrome where only links are only navigated to if they are within one of 
-    those two lists.
+      It was assumed that the extensions within Chrome were not capable of 
+      navigating to, downloading a file from a URL, or execute the downloaded 
+      file without user interaction. Thus the developers didn't originally think
+      to check that the target links given on the NTP should all be in the most-
+      visited or suggested link lists. The fix was to add another layer of defense
+      to Chrome where only links are only navigated to if they are within one of 
+      those two lists.
   least_privilege:
     applies: true
     note: |
-    Extensions themselves should not be allowed to download and execute code on 
-    user's computer outside of the Chrome sandbox, however this was possible due
-    to the nature of Flash applications.
+      Extensions themselves should not be allowed to download and execute code on 
+      user's computer outside of the Chrome sandbox, however this was possible due
+      to the nature of Flash applications.
   frameworks_are_optional:
     applies: false
     note: 
@@ -194,10 +193,10 @@ lessons:
   environment_variables:
     applies: true
     note: |
-    Combining this vulnerability with the intended insecure nature of Flash, an 
-    attacker can create an extension that runs a Flash program to pull anything
-    off the user's computer, an example given in the bug report was the contents
-    of '/etc/passwd' on Linux/Unix systems
+      Combining this vulnerability with the intended insecure nature of Flash, an 
+      attacker can create an extension that runs a Flash program to pull anything
+      off the user's computer, an example given in the bug report was the contents
+      of '/etc/passwd' on Linux/Unix systems
   secure_by_default:
     applies: false
     note: 
@@ -220,11 +219,11 @@ mistakes:
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
   answer: |
-  This vulnerability arose from the new functionality added to the NTP,
-  where Chrome will provide the user their most visited sites and some suggested
-  ones. Ultimately, this was a design mistake, because the developers never
-  thought that such an attack would be possible, and while no exploits of this
-  bug were ever created, it could have huge consequences if it ever was.
-  Additionally, between when the vulnerability was introduced and it's fix,
-  the system around it was moved around, allowing the bug to hide longer than
-  normal.
+    This vulnerability arose from the new functionality added to the NTP,
+    where Chrome will provide the user their most visited sites and some suggested
+    ones. Ultimately, this was a design mistake, because the developers never
+    thought that such an attack would be possible, and while no exploits of this
+    bug were ever created, it could have huge consequences if it ever was.
+    Additionally, between when the vulnerability was introduced and it's fix,
+    the system around it was moved around, allowing the bug to hide longer than
+    normal.

--- a/cves/CVE-2016-1625.yml
+++ b/cves/CVE-2016-1625.yml
@@ -16,10 +16,11 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-   A lack of a check on the link target of items on certain web pages served by
-   the browser itself coupled with the insecure nature of Flash, allowed attackers
-   to download and execute Flash programs through an extension in order to 
-   access any file on user's computers.
+   Due to a lack of checking agianst intended target web addresses, malicious 
+   extensions are capable of changing where suggested links brought users when 
+   clicked on. This allows extensions to navigate users to malicious websites, 
+   or run Flash programs on the host device. Remote attackers could then use 
+   this to grab any file out of the filesystem.
 bounty:
   date: 2016-02-09 14:32:00.000000000 -05:00
   amount: 1000.0
@@ -62,9 +63,10 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
   answer: |
-    This vulnerability involved a missing check in the code, there was no code
-    in place before the fix, the fix involved adding the check in the code, as
-    well as unit tests to check the functionality of the check.
+    This vulnerability involved a missing check in the code between the actual 
+    link targets and the expected list of links. There were no tests in place 
+    before the fix. Fixing this issue involved adding code to check for this
+    and unit tests to verify the issue was resolved.
   code: false
   fix: true
 discovered:
@@ -138,7 +140,7 @@ major_events:
     within this time which could help account for the length of time the vulnerability
     was active.
   events:
-  - name: Componentized Search functions, code was moved to another namespace to accomodate iOS.
+  - name: Componentized Search functions, code was moved to another namespace to accommodate iOS.
     date: 2015-08-03
   - name: Experimental code dealing with Most Visited Tiles on the NTP was removed from Chrome
     date: 2014-07-23
@@ -160,13 +162,14 @@ lessons:
   defense_in_depth:
     applies: true
     note: |
-      It was assumed that the extensions within Chrome were not capable of 
-      navigating to, downloading a file from a URL, or execute the downloaded 
-      file without user interaction. Thus the developers didn't originally think
-      to check that the target links given on the NTP should all be in the most-
-      visited or suggested link lists. The fix was to add another layer of defense
-      to Chrome where only links are only navigated to if they are within one of 
-      those two lists.
+      It was assumed that extensions within Chromium were incapable of changing
+      the link targets on the New Tab Page. This ability allowed them to direct
+      users to any website, or directly download and potentially run a file from 
+      another URL without further user interaction. Thus, the developers didn't 
+      originally think to check that the target links given on the NTP should all
+      be in the most-visited or suggested link lists to prevent this. The fix was
+      to add another layer of defense to Chromium where links are only navigated to
+      if they are within one of those two lists.
   least_privilege:
     applies: true
     note: |
@@ -218,10 +221,10 @@ mistakes:
     engineering industry would find interesting.
   answer: |
     This vulnerability arose from the new functionality added to the NTP,
-    where Chrome will provide the user their most visited sites and some suggested
-    ones. Ultimately, this was a design mistake, because the developers never
-    thought that such an attack would be possible, and while no exploits of this
-    bug were ever created, it could have huge consequences if it ever was.
-    Additionally, between when the vulnerability was introduced and it's fix,
-    the system around it was moved around, allowing the bug to hide longer than
-    normal.
+    where Chromium provides the user their most-visited sites and some suggested
+    ones, without checking that the target of the link was the same as the link itself.
+    Ultimately, this was a design mistake, because the developers never
+    thought that such an attack would be possible, and while no exploit of this
+    bug was ever created, it could have had huge consequences if it ever was.
+    Additionally, between when the vulnerability was introduced and its fix,
+    the subsystem was moved around, allowing the bug to hide longer than normal.

--- a/cves/CVE-2016-1625.yml
+++ b/cves/CVE-2016-1625.yml
@@ -20,7 +20,7 @@ description: |
    extensions are capable of changing where suggested links brought users when 
    clicked on. This allows extensions to navigate users to malicious websites, 
    or run Flash programs on the host device. Remote attackers could then use 
-   this to grab any file out of the filesystem.
+   this to grab any file from the host device.
 bounty:
   date: 2016-02-09 14:32:00.000000000 -05:00
   amount: 1000.0
@@ -49,7 +49,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes: 6
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -87,7 +87,8 @@ discovered:
   answer: |
     This vulnerability was originally brought to light by someone from Google
     that was able to grab the linux/unix password file from a system with a 
-    custom extension and some JavaScript.
+    custom extension that runs a JS script that forces the download of a Flash
+    program that when run, has access to any file on the host device.
   date: 2015-07-12
   automated: false
   google: true
@@ -111,24 +112,25 @@ interesting_commits:
   commits:
   - commit: ce767ab228df8ab9ee2664a258380ce9601fc42b
     note: |
-      Added support for forced URLs in the TopSites. Allows Chrome to force, and keep
-      top-sites according to the most recently used metric. Allows for certain sites
-      to appear on the New Tab Page over other web pages. Current implementation shows
-      only 8 sites on the NTP, so this provides more customization to those sites.
+      Added support for forced URLs in the TopSites of Chrome. Allows Chrome to force, 
+      and keep top-sites according to the most recently used metric. Allows for certain sites
+      to appear on the New Tab Page over other web pages in the most-visited list.
+      Current implementation shows only 8 sites on the NTP, so this provides more 
+      customization to those sites.
   - commit: 8d57a0152613119d7e6369838fd5838fb7773e68
     note: |
       Rework of the New Tab Page to remove anything that dealt with an older version of
       the NTP still referenced in the code. This is the second commit of this nature, the
-      first one was reverted.
+      first one was reverted due to a duplicate performance registration issues on Android.
   - commit: 982ecc2f027bc08255e8dd6a37017b69bde250f7
     note: |
       Experimental code used to test the Most Visited Tiles functionality on the New
       Tab Page is considered obsolete at this point and was removed from the repo.
   - commit: 51bbec7be7014d4d75d39c1a5c27b1ba9ddc3dcd
     note: |
-      Involved the movement of a fair number of the search functionality into a
-      different namespace. Could have attributed to the length of time this 
-      vulnerability sat in the repo.
+      Involved the movement of the browser's search functionality from a submodule of the
+      browser directly, into it's own namespace and module.
+      This could have attributed to the length of time this vulnerability sat in the repo.
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -139,7 +141,7 @@ major_events:
     we want to capture what the development team was dealing with at the time.
   answer: |
     It is assumed the team changed within the 3 years this vulnerability was active.
-    The New Tab Page and Chrome Instant, where both reworked and semi-componentized
+    The New Tab Page and Chrome Instant, were both reworked and semi-componentized
     within this time which could help account for the length of time the vulnerability
     was active.
   events:
@@ -178,7 +180,10 @@ lessons:
     note: |
       Extensions themselves should not be allowed to download and execute code on 
       user's computer outside of the Chrome sandbox, however this was possible due
-      to the nature of Flash applications.
+      to the insecure nature of Flash applications. The extension was capable of
+      downloading and running a Flash application, two things that they shouldn't
+      inherently be allowed to do. The Flash application, in turn is insecure to 
+      the point where it allows for access to the host device and any file on it.
   frameworks_are_optional:
     applies: false
     note: 

--- a/cves/CVE-2016-1625.yml
+++ b/cves/CVE-2016-1625.yml
@@ -16,12 +16,10 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-   The implementation of Chrome Instant on the New Tab Page, that shows the 
-   user their most-visted & suggested links, was not properly checking that 
-   the link targets on the page were in the suggested or most-visted link lists 
-   stored within Chrome. Attackers could use this vulnerability to bypass 
-   extension code-execution restrictions and download and run a flash file 
-   that can access any file on the user's computer (e.g. /etc/passwd)
+   A lack of a check on the link target of items on certain web pages served by
+   the browser itself coupled with the insecure nature of Flash, allowed attackers
+   to download and execute Flash programs through an extension in order to 
+   access any file on user's computers.
 bounty:
   date: 2016-02-09 14:32:00.000000000 -05:00
   amount: 1000.0
@@ -39,7 +37,7 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: d523a41aed4e321d4c8197b5cccb73be23c8dcc2
-  :note: ''
+  :note: Finally added check to fix issue
 vccs:
 - :commit: 064f57affdcdbc6b5e85bc1fc2082a5e393ff0af
   :note: initially created during fix for bug 272583

--- a/cves/CVE-2016-1625.yml
+++ b/cves/CVE-2016-1625.yml
@@ -16,7 +16,7 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-   Due to a lack of checking agianst intended target web addresses, malicious 
+   Due to a lack of checking against intended target web addresses, malicious 
    extensions are capable of changing where suggested links brought users when 
    clicked on. This allows extensions to navigate users to malicious websites, 
    or run Flash programs on the host device. Remote attackers could then use 
@@ -84,7 +84,10 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer: ''
+  answer: |
+    This vulnerability was originally brought to light by someone from Google
+    that was able to grab the linux/unix password file from a system with a 
+    custom extension and some JavaScript.
   date: 2015-07-12
   automated: false
   google: true

--- a/cves/CVE-2016-1625.yml
+++ b/cves/CVE-2016-1625.yml
@@ -138,11 +138,9 @@ major_events:
     within this time which could help account for the length of time the vulnerability
     was active.
   events:
-  - name: |
-  Componentized Search functions, code was moved to another namespace to accomodate iOS.
+  - name: Componentized Search functions, code was moved to another namespace to accomodate iOS.
     date: 2015-08-03
-  - name: |
-  Experimental code dealing with Most Visited Tiles on the NTP was removed from Chrome
+  - name: Experimental code dealing with Most Visited Tiles on the NTP was removed from Chrome
     date: 2014-07-23
 lessons:
   question: |

--- a/cves/CVE-2016-1625.yml
+++ b/cves/CVE-2016-1625.yml
@@ -1,6 +1,6 @@
 ---
 CVE: CVE-2016-1625
-CWE: 
+CWE: 264
 announced: 2016-02-13 21:59:03.130000000 -05:00
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -15,7 +15,13 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description: |
+   The implementation of Chrome Instant on the New Tab Page, that shows the 
+   user their most-visted & suggested links, was not properly checking that 
+   the link targets on the page were in the suggested or most-visted link lists 
+   stored within Chrome. Attackers could use this vulnerability to bypass 
+   extension code-execution restrictions and download and run a flash file 
+   that can access any file on the user's computer (e.g. /etc/passwd)
 bounty:
   date: 2016-02-09 14:32:00.000000000 -05:00
   amount: 1000.0
@@ -34,7 +40,9 @@ fixes_vcc_instructions: |
 fixes:
 - :commit: d523a41aed4e321d4c8197b5cccb73be23c8dcc2
   :note: ''
-vccs: []
+vccs:
+- :commit: 064f57affdcdbc6b5e85bc1fc2082a5e393ff0af
+  :note: initially created during fix for bug 272583
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -55,9 +63,12 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer: |
+    This vulnerability involved a missing check in the code, there was no code
+    in place before the fix, the fix involved adding the check in the code, as
+    well as unit tests to check the functionality of the check.
+  code: false
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -66,18 +77,19 @@ discovered:
     originally found. Answer in longform below in "answer", fill in the date in
     YYYY-MM-DD, and then determine if the vulnerability was found by a Google
     employee (you can tell from their email address). If it's clear that the
-    vulenrability was discovered by a contest, fill in the name there.
+    vulnerability was discovered by a contest, fill in the name there.
 
     The "automated" flag can be true, false, or nil.
     The "google" flag can be true, false, or nil.
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer: |
+  
+  date: 2015-07-12
+  automated: false
+  google: true
+  contest: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -85,8 +97,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
-  answer: 
-  name: 
+  answer: Chrome Instant on the New Tab Page
+  name: New Tab Page
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -95,10 +107,26 @@ interesting_commits:
     interesting in light of the lessons learned from this vulnerability. Any
     emerging themes?
   commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+  - commit: ce767ab228df8ab9ee2664a258380ce9601fc42b
+    note: |
+    Added support for forced URLs in the TopSites. Allows Chrome to force, and keep
+    top-sites according to the most recently used metric. Allows for certain sites
+    to appear on the New Tab Page over other web pages. Current implementation shows
+    only 8 sites on the NTP, so this provides more customization to those sites.
+  - commit: 8d57a0152613119d7e6369838fd5838fb7773e68
+    note: |
+    Rework of the New Tab Page to remove anything that dealt with an older version of
+    the NTP still referenced in the code. This is the second commit of this nature, the
+    first one was reverted.
+  - commit: 982ecc2f027bc08255e8dd6a37017b69bde250f7
+    note: |
+    Experimental code used to test the Most Visited Tiles functionality on the New
+    Tab Page is considered obsolete at this point and was removed from the repo.
+  - commit: 51bbec7be7014d4d75d39c1a5c27b1ba9ddc3dcd
+    note: |
+    Involved the movement of a fair number of the search functionality into a
+    different namespace. Could have attributed to the length of time this 
+    vulnerability sat in the repo.
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -107,12 +135,18 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
+  answer: |
+  It is assumed the team changed within the 3 years this vulnerability was active.
+  The New Tab Page and Chrome Instant, where both reworked and semi-componentized
+  within this time which could help account for the length of time the vulnerability
+  was active.
   events:
-  - name: 
-    date: 
-  - name: 
-    date: 
+  - name: Componentized Search functions, code was moved to another namespace to
+  accomodate Chrome on iOS.
+    date: 2015-08-03
+  - name: Experimental code dealing with Most Visited Tiles on the NTP was removed 
+  from Chrome
+    date: 2014-07-23
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -129,37 +163,51 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies: 
-    note: 
+    applies: true
+    note: |
+    It was assumed that the extensions within Chrome were not capable of 
+    navigating to, downloading a file from a URL, or execute the downloaded 
+    file without user interaction. Thus the developers didn't originally think
+    to check that the target links given on the NTP should all be in the most-
+    visited or suggested link lists. The fix was to add another layer of defense
+    to Chrome where only links are only navigated to if they are within one of 
+    those two lists.
   least_privilege:
-    applies: 
-    note: 
+    applies: true
+    note: |
+    Extensions themselves should not be allowed to download and execute code on 
+    user's computer outside of the Chrome sandbox, however this was possible due
+    to the nature of Flash applications.
   frameworks_are_optional:
-    applies: 
+    applies: false
     note: 
   native_wrappers:
-    applies: 
+    applies: false
     note: 
   distrust_input:
-    applies: 
+    applies: false
     note: 
   security_by_obscurity:
-    applies: 
+    applies: false
     note: 
   serial_killer:
-    applies: 
+    applies: false
     note: 
   environment_variables:
-    applies: 
-    note: 
+    applies: true
+    note: |
+    Combining this vulnerability with the intended insecure nature of Flash, an 
+    attacker can create an extension that runs a Flash program to pull anything
+    off the user's computer, an example given in the bug report was the contents
+    of '/etc/passwd' on Linux/Unix systems
   secure_by_default:
-    applies: 
+    applies: false
     note: 
   yagni:
-    applies: 
+    applies: false
     note: 
   complex_inputs:
-    applies: 
+    applies: false
     note: 
 mistakes:
   question: |
@@ -173,4 +221,12 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+  This vulnerability arose from the new functionality added to the NTP,
+  where Chrome will provide the user their most visited sites and some suggested
+  ones. Ultimately, this was a design mistake, because the developers never
+  thought that such an attack would be possible, and while no exploits of this
+  bug were ever created, it could have huge consequences if it ever was.
+  Additionally, between when the vulnerability was introduced and it's fix,
+  the system around it was moved around, allowing the bug to hide longer than
+  normal.


### PR DESCRIPTION
Updated vulnerability information for CVE-2016-1625 & CVE-2011-3045  
  
**CVE-2016-1625**: Vulnerability with the New Tab Page in Chromium.  
**CVE-2011-3045**: Vulnerability with libpng and an integer overflow possibility.
