### PR TITLE
CVE-2015-1296 CVE-2016-5161

### DIFF
--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -1,6 +1,6 @@
 ---
 CVE: CVE-2015-1296
-CWE: CWE-20
+CWE: 20
 announced: 2015-09-03 18:59:06.813000000 -04:00
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -20,8 +20,8 @@ description:
     character would be displayed at the beginning of the URL which could fool
     the user into thinking that they had a secure connection over HTTPS.
     Attackers could post links anywhere on the web that include these special
-    characters so when people click on them and see the padlock icond they'd
-    think that they're safe.Also, there isn't really a commit that introduced
+    characters so when people click on them and see the padlock icon they'd
+    think that they're safe. Also, there isn't really a commit that introduced
     the vulnerability. It has been around since the beginning of the project, as
     long as they had the OmniBox and the SSL padlock icon this was an issue.
 bounty:
@@ -115,7 +115,7 @@ interesting_commits:
   commits:
   - commit: 2cd905494ba700a8e2097d614ed39ad36d1519f2
     note: |
-        Here they added a more unicode characters to be escaped in URLs, like
+        Here they added more unicode characters to be escaped in URLs, like
         U+202A LEFT-TO-RIGHT EMBEDDING and a few others. Also, the unicode spec
         was updated so they added excepctions for the new bidrectional
         characters.

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -1,6 +1,6 @@
 ---
 CVE: CVE-2015-1296
-CWE: 
+CWE:
 announced: 2015-09-03 18:59:06.813000000 -04:00
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -15,7 +15,13 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description:
+    You could place special unicode characters in the URL so that a padlock
+    character would be displayed at the beginning of the URL which could fool
+    the user into thinking that they had a secure connection over HTTPS. Also,
+    there isn't really a commit that introduced the vulnerability. It has been
+    around since the beginning of the project, as long as they had the OmniBox
+    and the SSL padlock icon this was an issue.
 bounty:
   date: 2015-09-01 15:15:00.000000000 -04:00
   amount: 1000.0
@@ -26,15 +32,15 @@ reviews:
 - 1189553002
 bugs:
 - 421332
-repo: 
+repo:
 fixes_vcc_instructions: |
   Please put the commit hash in "commit" below (see my example in
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: 7c2cbc445a81424c7df48ebe61ec4d0dcadd5dff
-  :note: ''
+  :note: 'They blacklisted the unicode padlock characters.'
 - :commit: 1c7d9ce02925cf766fc508d4ee83424369e71548
-  :note: ''
+  :note: 'Changed it so RTL URLs wont be completely flipped around'
 vccs: []
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
@@ -43,7 +49,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes:
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -56,9 +62,15 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer: |
+      The code was tested before this fix was introduced, they just didn't
+      consider the padlock characters before.
+  code: |
+      The code was tested before this fix was introduced, they just didn't
+      consider the padlock characters before.
+  fix: |
+      Once the padlock characters were blacklisted another test case was to
+      verify that these characters were removed.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -74,11 +86,11 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer: It was reported by zcor...@gmail.com
+  date: 2014-10-08
+  automated: false
+  google: false
+  contest: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -86,8 +98,10 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
-  answer: 
-  name: 
+  answer: |
+    It affected the omnibox but the issue was in the core of the system, in
+    netloc/core/
+  name: OmniBox
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -96,10 +110,14 @@ interesting_commits:
     interesting in light of the lessons learned from this vulnerability. Any
     emerging themes?
   commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+  - commit: 2cd905494ba700a8e2097d614ed39ad36d1519f2
+    note: |
+        Here they added a more unicode characters to be escaped in URLs, like
+        U+202A LEFT-TO-RIGHT EMBEDDING and a few others. Also, the unicode spec
+        was updated so they added excepctions for the new bidrectional
+        characters.
+  - commit:
+    note:
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -108,12 +126,15 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
+  answer: |
+    There weren't really any major events around this. They had a few issues
+    with unicode and with the omnibox but neither of them got major rehauls
+    around the time of this vulnerability.
   events:
-  - name: 
-    date: 
-  - name: 
-    date: 
+  - name:
+    date:
+  - name:
+    date:
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -130,38 +151,42 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies: 
-    note: 
+    applies: false
+    note:
   least_privilege:
-    applies: 
-    note: 
+    applies: false
+    note:
   frameworks_are_optional:
-    applies: 
-    note: 
+    applies: false
+    note:
   native_wrappers:
-    applies: 
-    note: 
+    applies: false
+    note:
   distrust_input:
-    applies: 
-    note: 
+    applies: true
+    note: |
+        There are certain unicode characters that can appear to spoof the SSL
+        padlock icon that they didn't remove from the input.
   security_by_obscurity:
-    applies: 
-    note: 
+    applies: false
+    note:
   serial_killer:
-    applies: 
-    note: 
+    applies: false
+    note:
   environment_variables:
-    applies: 
-    note: 
+    applies: false
+    note:
   secure_by_default:
-    applies: 
-    note: 
+    applies: false
+    note:
   yagni:
-    applies: 
-    note: 
+    applies: false
+    note:
   complex_inputs:
-    applies: 
-    note: 
+    applies: true
+    note: |
+        There are complex unicode inputs with special charcters in RTL mode
+        that could spoof the SSL padlock.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -174,4 +199,8 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer: |
+    This issue happened at the Requirements phase. They should have considered
+    all of the complex unicode inputs that people could use to attempt to spoof
+    URLs. This is a really complex input so it's understandable that they never
+    considered it originally though.

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -24,9 +24,7 @@ description:
     think that they're safe. They could hide them with a hyperlink so that the
     characters don't appear in the link visible to the user, but when the click 
     on it the web browser would copy it to the omnibox and display the padlock
-    character. Also, there isn't really a commit that introduced the 
-    vulnerability. It has been around since the beginning of the project, as
-    long as they had the OmniBox and the SSL padlock icon this was an issue.
+    character.
 bounty:
   date: 2015-09-01 15:15:00.000000000 -04:00
   amount: 1000.0
@@ -92,7 +90,10 @@ discovered:
     the bug. He also was put in the chrome release notes for finding it. It does
     say though that if he disclosed the bug information before it was fixed then
     he wouldn't get the money anymore. It doesn't say how zorcpan found the bug.
-    All of this information was obtained from the bug report on chromium.org.
+    All of this information was obtained from the bug report on chromium.org. 
+    Also, there isn't really a commit that introduced the vulnerability. It has 
+    been around since the beginning of the project, as long as they had the 
+    OmniBox and the SSL padlock icon this was an issue.
   date: 2014-10-08
   automated: false
   google: false
@@ -208,5 +209,10 @@ mistakes:
   answer: |
     This issue happened at the Requirements phase. They should have considered
     all of the complex unicode inputs that people could use to attempt to spoof
-    URLs. This is a really complex input so it's understandable that they never
-    considered it originally though.
+    URLs. In order for this type of vulnerability to be caught they would have 
+    needed to have someone who is very familiar with unicode to be on the team.
+    This person would have to know about the padlock character and know that 
+    there are RTL characters that can be used to move characters to appear at
+    the beginning of the string. Throughout all of development no one must have
+    thought of an attack like this. It's a really complex input so it's 
+    understandable that they never considered it originally though.

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -1,6 +1,6 @@
 ---
 CVE: CVE-2015-1296
-CWE:
+CWE: CWE-20
 announced: 2015-09-03 18:59:06.813000000 -04:00
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -64,9 +64,7 @@ unit_tested:
     adding or improving an automated test to ensure this doesn't happen again.
   answer: true
   code: true
-  fix: |
-      Once the padlock characters were blacklisted another test case was to
-      verify that these characters were removed.
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -58,7 +58,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 10
+upvotes: 17
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -220,6 +220,6 @@ mistakes:
     the beginning of the string. Throughout all of development no one must have
     thought of an attack like this. It's a really complex input so it's 
     understandable that they never considered it originally though. They couldn't
-    remove all unicode characters though because people who speak languages who's
+    remove all unicode characters though because people who speak languages whose
     alphabet doesn't fit in ASCII need to be able to search for things with the
     omnibox.

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -21,10 +21,14 @@ description:
     the user into thinking that they had a secure connection over HTTPS.
     Attackers could post links anywhere on the web that include these special
     characters so when people click on them and see the padlock icon they'd
-    think that they're safe. They could hide them with a hyperlink so that the
-    characters don't appear in the link visible to the user, but when the click 
-    on it the web browser would copy it to the omnibox and display the padlock
-    character.
+    think that they're safe. The padlock icon verifies that the server is in
+    fact who they claim to be. If you go on Facebook.com and see the padlock
+    then it verifies that there isn't a third party impersonating Facebook.
+    They could hide them with a hyperlink so that the characters don't appear 
+    in the link visible to the user, but when they click on it the web browser 
+    would copy it to the omnibox and display the padlock character. The
+    omnibox is the address bar in chrome, they just call in the omnibox 
+    internally.
 bounty:
   date: 2015-09-01 15:15:00.000000000 -04:00
   amount: 1000.0
@@ -46,7 +50,7 @@ fixes:
   :note: 'Changed it so RTL URLs wont be completely flipped around'
 vccs:
 - commit: c14d891d44f0afff64e56ed7c9702df1d807b1ee
-  note: This is the initial commit in their git repo.
+  note: This is the initial commit in the Google Chrome git repo.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -121,7 +125,7 @@ interesting_commits:
     note: |
         Here they added more unicode characters to be escaped in URLs, like
         U+202A LEFT-TO-RIGHT EMBEDDING and a few others. Also, the unicode spec
-        was updated so they added excepctions for the new bidrectional
+        was updated so they added exceptions for the new bidrectional
         characters.
   - commit:
     note:
@@ -215,4 +219,7 @@ mistakes:
     there are RTL characters that can be used to move characters to appear at
     the beginning of the string. Throughout all of development no one must have
     thought of an attack like this. It's a really complex input so it's 
-    understandable that they never considered it originally though.
+    understandable that they never considered it originally though. They couldn't
+    remove all unicode characters though because people who speak languages who's
+    alphabet doesn't fit in ASCII need to be able to search for things with the
+    omnibox.

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -18,10 +18,12 @@ description_instructions: |
 description:
     You could place special unicode characters in the URL so that a padlock
     character would be displayed at the beginning of the URL which could fool
-    the user into thinking that they had a secure connection over HTTPS. Also,
-    there isn't really a commit that introduced the vulnerability. It has been
-    around since the beginning of the project, as long as they had the OmniBox
-    and the SSL padlock icon this was an issue.
+    the user into thinking that they had a secure connection over HTTPS.
+    Attackers could post links anywhere on the web that include these special
+    characters so when people click on them and see the padlock icond they'd
+    think that they're safe.Also, there isn't really a commit that introduced
+    the vulnerability. It has been around since the beginning of the project, as
+    long as they had the OmniBox and the SSL padlock icon this was an issue.
 bounty:
   date: 2015-09-01 15:15:00.000000000 -04:00
   amount: 1000.0
@@ -41,7 +43,9 @@ fixes:
   :note: 'They blacklisted the unicode padlock characters.'
 - :commit: 1c7d9ce02925cf766fc508d4ee83424369e71548
   :note: 'Changed it so RTL URLs wont be completely flipped around'
-vccs: []
+vccs:
+- commit: c14d891d44f0afff64e56ed7c9702df1d807b1ee
+  note: This is the initial commit in their git repo.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -49,7 +53,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 10
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -80,7 +84,12 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer: It was reported by zcor...@gmail.com
+  answer: |
+    It was reported by zcorpan and he received a reward of $1000 for finding
+    the bug. He also was put in the chrome release notes for finding it. It does
+    say though that if he disclosed the bug information before it was fixed then
+    he wouldn't get the money anymore. It doesn't say how zorcpan found the bug.
+    All of this information was obtained from the bug report on chromium.org.
   date: 2014-10-08
   automated: false
   google: false

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -21,8 +21,11 @@ description:
     the user into thinking that they had a secure connection over HTTPS.
     Attackers could post links anywhere on the web that include these special
     characters so when people click on them and see the padlock icon they'd
-    think that they're safe. Also, there isn't really a commit that introduced
-    the vulnerability. It has been around since the beginning of the project, as
+    think that they're safe. They could hide them with a hyperlink so that the
+    characters don't appear in the link visible to the user, but when the click 
+    on it the web browser would copy it to the omnibox and display the padlock
+    character. Also, there isn't really a commit that introduced the 
+    vulnerability. It has been around since the beginning of the project, as
     long as they had the OmniBox and the SSL padlock icon this was an issue.
 bounty:
   date: 2015-09-01 15:15:00.000000000 -04:00

--- a/cves/CVE-2015-1296.yml
+++ b/cves/CVE-2015-1296.yml
@@ -62,12 +62,8 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: |
-      The code was tested before this fix was introduced, they just didn't
-      consider the padlock characters before.
-  code: |
-      The code was tested before this fix was introduced, they just didn't
-      consider the padlock characters before.
+  answer: true
+  code: true
   fix: |
       Once the padlock characters were blacklisted another test case was to
       verify that these characters were removed.

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -1,6 +1,6 @@
 ---
 CVE: CVE-2016-5161
-CWE:
+CWE: CWE-229
 announced: 2016-09-11 06:59:17.817000000 -04:00
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -61,11 +61,7 @@ unit_tested:
     adding or improving an automated test to ensure this doesn't happen again.
   answer: true
   code: true
-  fix: |
-      There was a unit test added specifically for the vulnerability they fixed.
-      They added a test with the HTML/CSS that broke it and made sure that
-      the new solution works properly. The test is in the same directory as the
-      code file that was fixed and is called EditingStyleTest.cpp.
+  fix: true
 discovered:
   question: |
     How was this vulnerability discovered?

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -20,7 +20,11 @@ description: |
   when merging styles together. Their old implementation serialized the CSS
   property value and then reparsed it which didn't preserve the name of the
   custom property. Someone could construct a custom property that would cause a
-  denial of service for Chrome.
+  denial of service for Chrome. In their test example the CSS that was causing
+  the issue was '--A:var(---B)' and 'float:var(--C)' applied to two spans. When
+  these styles were merged it would create a case where the system could end up
+  reading memory that wasn't allocated which could result in a segmentation
+  fault.
 bounty:
   date:
   amount:
@@ -39,6 +43,10 @@ fixes:
   :note: ''
 vccs: [3404893f208a8fe55d2f137d240ea3901b951757,
 43ebfe1051df6ec676c14c68011d24f8fd356619]
+- commit: 3404893f208a8fe55d2f137d240ea3901b951757
+  note: Fixed a different issue with merging styles.
+- commit: 43ebfe1051df6ec676c14c68011d24f8fd356619
+  note: Changed around the architecture to make it more modularized.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -46,7 +54,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 3
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -195,4 +203,6 @@ mistakes:
     engineering industry would find interesting.
   answer: |
       It was a design mistake. They failed to consider a certain type of input,
-      which when entered had the potential to break their system.
+      which when entered had the potential to break their system. They should
+      have considered CSS properties with custom values when desiging the
+      merging functionality.

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -1,6 +1,6 @@
 ---
 CVE: CVE-2016-5161
-CWE: CWE-229
+CWE: 229
 announced: 2016-09-11 06:59:17.817000000 -04:00
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -41,8 +41,7 @@ fixes_vcc_instructions: |
 fixes:
 - :commit: aadb63893e4c1358d1e5139aa29552eb190682c8
   :note: ''
-vccs: [3404893f208a8fe55d2f137d240ea3901b951757,
-43ebfe1051df6ec676c14c68011d24f8fd356619]
+vccs:
 - commit: 3404893f208a8fe55d2f137d240ea3901b951757
   note: Fixed a different issue with merging styles.
 - commit: 43ebfe1051df6ec676c14c68011d24f8fd356619

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -16,15 +16,13 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-  There was an issue in with custom CSS properties in Google chrome
-  when merging styles together. Their old implementation serialized the CSS
-  property value and then reparsed it which didn't preserve the name of the
-  custom property. Someone could construct a custom property that would cause a
-  denial of service for Chrome. In their test example the CSS that was causing
-  the issue was '--A:var(---B)' and 'float:var(--C)' applied to two spans. When
-  these styles were merged it would create a case where the system could end up
-  reading memory that wasn't allocated which could result in a segmentation
-  fault.
+  In Google Chrome there was an issue with merging certain CSS styles together.
+  Their old implementation serialized the CSS property value and then reparsed 
+  it which didn't preserve the name of the custom property. In their test example 
+  the CSS that was causing the issue was '--A:var(---B)' and 'float:var(--C)' 
+  when applied to two spans.  When these styles were merged it would create a 
+  case where the system could end up reading memory that wasn't allocated which 
+  could result in a segmentation fault, which could be a denial of service.
 bounty:
   date:
   amount:
@@ -85,10 +83,12 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
   answer: |
-      It was discovered by 62600BCA031B9EB5CB4A74ADDDD6771E at Trend Micro's
-      Zero Day Initiative. It was reported on the bug site by zdi-disc...@hp.com
-      and it looks like either the ... is part of the email or there's an issue
-      with the site.
+      It was discovered someone working at Trend Micro's Zero Day Initiative. It 
+      was reported on the bug site by zdi-disc...@hp.com and it looks like either 
+      the ... is part of the email or there's an issue with the site. Trend Micro
+      is an organization that rewards researchers for reporting bugs to vendors
+      instead of trying to sell them or something to people with malicious 
+      intentions.
   date: 2016-06-22
   automated: false
   google: false
@@ -115,7 +115,11 @@ interesting_commits:
   - commit: d8055bceb97d14e28bdbce373062705ce080f014
     note: |
         Here they changed from using an iterator to using a for loop with an
-        index.
+        index. I think this is pretty interesting because in C++ there are so
+        many different ways to do things at the language level and it's cool
+        to see the conventions that big companies follow. It's odd that they
+        changed something like this, maybe it was just the developer's
+        preference.
   - commit:
     note:
 major_events:
@@ -165,9 +169,9 @@ lessons:
   distrust_input:
     applies: true
     note: |
-        They're issue wasn't completely related to this because it should
+        Their issue wasn't completely related to this because it should
         have been able to understand the CSS, but they had failed to consider
-        a speicific type of input.
+        a specific type of input.
   security_by_obscurity:
     applies: false
     note:
@@ -205,7 +209,7 @@ mistakes:
       which when entered had the potential to break their system. They should
       have considered CSS properties with custom values when desiging the
       merging functionality. They should have had people who are experts in CSS
-      looking over the code to make sure that their implmentation conforms to
+      looking over the code to make sure that their implementation conforms to
       the standards, the stakes are high for a project like this and google
       definitely has the resources. They also could have written tests for all
       of the different types of CSS inputs to make sure the merging worked as

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -1,6 +1,6 @@
 ---
 CVE: CVE-2016-5161
-CWE: 
+CWE:
 announced: 2016-09-11 06:59:17.817000000 -04:00
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -15,24 +15,30 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description: 
+description:
+  There was an issue in Google Chrome with custom CSS properties in Google chrome
+  when merging styles together. Their old implementation serialized the CSS
+  property value and then reparsed it which didn't preserve the name of the
+  custom property. Someone could construct a custom property that would cause a
+  denial of service for Chrome.
 bounty:
-  date: 
-  amount: 
+  date:
+  amount:
   references: []
 reviews:
 - 2103043004
 - 2245573002
 bugs:
 - 622420
-repo: 
+repo:
 fixes_vcc_instructions: |
   Please put the commit hash in "commit" below (see my example in
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
 - :commit: aadb63893e4c1358d1e5139aa29552eb190682c8
   :note: ''
-vccs: []
+vccs: [3404893f208a8fe55d2f137d240ea3901b951757,
+43ebfe1051df6ec676c14c68011d24f8fd356619]
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -40,7 +46,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 
+upvotes:
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -53,9 +59,15 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: 
-  code: 
-  fix: 
+  answer:
+      The original code had tests, just not for this vulnerability.
+  code:
+      The original code had tests, just not for this vulnerability.
+  fix:
+      There was a unit test added specifically for the vulnerability they fixed.
+      They added a test with the HTML/CSS that broke it and made sure that
+      the new solution works properly. The test is in the same directory as the
+      code file that was fixed and is called EditingStyleTest.cpp.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -71,11 +83,19 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer: 
-  date: 
-  automated: 
-  google: 
-  contest: 
+  answer:
+      It was discovered by 62600BCA031B9EB5CB4A74ADDDD6771E at Trend Micro's
+      Zero Day Initiative. It was reported on the bug site by zdi-disc...@hp.com
+      and it looks like either the ... is part of the email or there's an issue
+      with the site.
+  date:
+      2016-06-22
+  automated:
+      false
+  google:
+      false
+  contest:
+      true
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -83,8 +103,10 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
-  answer: 
-  name: 
+  answer:
+      It was in the third party library WebKit.
+  name:
+      WebKit
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -93,10 +115,11 @@ interesting_commits:
     interesting in light of the lessons learned from this vulnerability. Any
     emerging themes?
   commits:
-  - commit: 
-    note: 
-  - commit: 
-    note: 
+  - commit: d8055bceb97d14e28bdbce373062705ce080f014
+    note: Here they changed from using an iterator to using a for loop with an
+    index.
+  - commit:
+    note:
 major_events:
   question: |
     Please record any major events you found in the history of this
@@ -105,12 +128,14 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: 
+  answer: I saw in one of the commits that in WebCore they were trying to only
+  expose the CSSOM API in CSSStyleDeclaration, they said they want "to split the
+  CSSOM API from the internal implementation."
   events:
-  - name: 
-    date: 
-  - name: 
-    date: 
+  - name: Trying split CSSOM API
+    date: 2012-01-30
+  - name:
+    date:
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -127,38 +152,41 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies: 
-    note: 
+    applies: false
+    note:
   least_privilege:
-    applies: 
-    note: 
+    applies: false
+    note:
   frameworks_are_optional:
-    applies: 
-    note: 
+    applies: false
+    note:
   native_wrappers:
-    applies: 
-    note: 
+    applies: false
+    note:
   distrust_input:
-    applies: 
-    note: 
+    applies: true
+    note: They're issue wasn't completely related to this because it should
+    have been able to understand the CSS, but they had failed to consider
+    a speicific type of input.
   security_by_obscurity:
-    applies: 
-    note: 
+    applies: false
+    note:
   serial_killer:
-    applies: 
-    note: 
+    applies: false
+    note:
   environment_variables:
-    applies: 
-    note: 
+    applies: false
+    note:
   secure_by_default:
-    applies: 
-    note: 
+    applies: false
+    note:
   yagni:
-    applies: 
-    note: 
+    applies: false
+    note:
   complex_inputs:
-    applies: 
-    note: 
+    applies: true
+    note: There was some CSS that they hadn't considered with custom properties,
+    and that broke their code.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -171,4 +199,6 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer: 
+  answer:
+      It was a design mistake. They failed to consider a certain type of input,
+      which when entered had the potential to break their system.

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -204,4 +204,9 @@ mistakes:
       It was a design mistake. They failed to consider a certain type of input,
       which when entered had the potential to break their system. They should
       have considered CSS properties with custom values when desiging the
-      merging functionality.
+      merging functionality. They should have had people who are experts in CSS
+      looking over the code to make sure that their implmentation conforms to
+      the standards, the stakes are high for a project like this and google
+      definitely has the resources. They also could have written tests for all
+      of the different types of CSS inputs to make sure the merging worked as
+      expected for a variety of inputs.

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -59,10 +59,8 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: |
-      The original code had tests, just not for this vulnerability.
-  code: |
-      The original code had tests, just not for this vulnerability.
+  answer: true
+  code: true
   fix: |
       There was a unit test added specifically for the vulnerability they fixed.
       They added a test with the HTML/CSS that broke it and made sure that

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -16,7 +16,7 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-  There was an issue in Google Chrome with custom CSS properties in Google chrome
+  There was an issue in with custom CSS properties in Google chrome
   when merging styles together. Their old implementation serialized the CSS
   property value and then reparsed it which didn't preserve the name of the
   custom property. Someone could construct a custom property that would cause a

--- a/cves/CVE-2016-5161.yml
+++ b/cves/CVE-2016-5161.yml
@@ -15,7 +15,7 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description:
+description: |
   There was an issue in Google Chrome with custom CSS properties in Google chrome
   when merging styles together. Their old implementation serialized the CSS
   property value and then reparsed it which didn't preserve the name of the
@@ -59,11 +59,11 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer:
+  answer: |
       The original code had tests, just not for this vulnerability.
-  code:
+  code: |
       The original code had tests, just not for this vulnerability.
-  fix:
+  fix: |
       There was a unit test added specifically for the vulnerability they fixed.
       They added a test with the HTML/CSS that broke it and made sure that
       the new solution works properly. The test is in the same directory as the
@@ -83,19 +83,15 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer:
+  answer: |
       It was discovered by 62600BCA031B9EB5CB4A74ADDDD6771E at Trend Micro's
       Zero Day Initiative. It was reported on the bug site by zdi-disc...@hp.com
       and it looks like either the ... is part of the email or there's an issue
       with the site.
-  date:
-      2016-06-22
-  automated:
-      false
-  google:
-      false
-  contest:
-      true
+  date: 2016-06-22
+  automated: false
+  google: false
+  contest: true
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -103,9 +99,9 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
-  answer:
+  answer: |
       It was in the third party library WebKit.
-  name:
+  name: |
       WebKit
 interesting_commits:
   question: |
@@ -116,8 +112,9 @@ interesting_commits:
     emerging themes?
   commits:
   - commit: d8055bceb97d14e28bdbce373062705ce080f014
-    note: Here they changed from using an iterator to using a for loop with an
-    index.
+    note: |
+        Here they changed from using an iterator to using a for loop with an
+        index.
   - commit:
     note:
 major_events:
@@ -128,9 +125,10 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer: I saw in one of the commits that in WebCore they were trying to only
-  expose the CSSOM API in CSSStyleDeclaration, they said they want "to split the
-  CSSOM API from the internal implementation."
+  answer: |
+    I saw in one of the commits that in WebCore they were trying to only
+    expose the CSSOM API in CSSStyleDeclaration, they said they want "to split
+    the CSSOM API from the internal implementation."
   events:
   - name: Trying split CSSOM API
     date: 2012-01-30
@@ -165,9 +163,10 @@ lessons:
     note:
   distrust_input:
     applies: true
-    note: They're issue wasn't completely related to this because it should
-    have been able to understand the CSS, but they had failed to consider
-    a speicific type of input.
+    note: |
+        They're issue wasn't completely related to this because it should
+        have been able to understand the CSS, but they had failed to consider
+        a speicific type of input.
   security_by_obscurity:
     applies: false
     note:
@@ -185,8 +184,9 @@ lessons:
     note:
   complex_inputs:
     applies: true
-    note: There was some CSS that they hadn't considered with custom properties,
-    and that broke their code.
+    note: |
+        There was some CSS that they hadn't considered with custom properties,
+        and that broke their code.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -199,6 +199,6 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
       It was a design mistake. They failed to consider a certain type of input,
       which when entered had the potential to break their system.


### PR DESCRIPTION
CVE-2015-1296: By manipulating URLs with special unicode characters attackers could make a padlock character appear to spoof the SSL icon.
CVE-2016-5161: Failing to consider custom variables in CSS caused a potential for DOS when merging styles.